### PR TITLE
Only clone EXH once when creating excel sheet

### DIFF
--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -126,7 +126,7 @@ pub fn generic_read_excel_sheet_header<R: Resource + ?Sized>(
 /// Read an excel sheet by name (e.g. "Achievement"). You most likely want to use the method in `ResourceResolver.`
 pub fn generic_read_excel_sheet<R: Resource + ?Sized>(
     resource: &mut R,
-    exh: EXH,
+    exh: &EXH,
     name: &str,
     language: Language,
 ) -> Result<ExcelSheet, Error> {
@@ -136,7 +136,7 @@ pub fn generic_read_excel_sheet<R: Resource + ?Sized>(
         pages.push(ExcelSheetPage::from_exd(page, &exh, exd));
     }
 
-    Ok(ExcelSheet { exh, pages })
+    Ok(ExcelSheet { exh: exh.clone(), pages })
 }
 
 /// Returns all known sheet names listed in the root list. You most likely want to use the method in `ResourceResolver.`

--- a/src/resource/resolver.rs
+++ b/src/resource/resolver.rs
@@ -90,12 +90,12 @@ impl ResourceResolver {
     /// Read an excel sheet by name (e.g. "Achievement").
     pub fn read_excel_sheet(
         &mut self,
-        exh: EXH,
+        exh: &EXH,
         name: &str,
         language: Language,
     ) -> Result<ExcelSheet, Error> {
         self.execute_first_found(
-            |resource| generic_read_excel_sheet(resource, exh.clone(), name, language),
+            |resource| generic_read_excel_sheet(resource, exh, name, language),
             Error::Unknown,
         )
     }

--- a/src/resource/sqpack.rs
+++ b/src/resource/sqpack.rs
@@ -453,7 +453,7 @@ impl SqPackResource {
     /// Read an excel sheet by name (e.g. "Achievement").
     pub fn read_excel_sheet(
         &mut self,
-        exh: EXH,
+        exh: &EXH,
         name: &str,
         language: Language,
     ) -> Result<ExcelSheet, Error> {


### PR DESCRIPTION
Switch to borrowing the EXH when creating an excel sheet, and only clone once at the end and rather than many times in a loop.

Minor performance gain, probably not very noticable in many cases, but just something I stumbled across while rewriting some of my code and wondered why it was moving EXH. It makes sense since the sheet you get has the EXH attached to it, so if you really did want to move the EXH reference you could still do so in `read_excel_sheet` and just pass it by ref to `generic_read_excel_sheet`