### PR TITLE
Support for water meshes

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1125,11 +1125,11 @@ impl ReadableFile for MDL {
 
 fn get_part_type(lod: &MeshLod, index: u16) -> Option<PartType> {
     if (lod.mesh_index..lod.mesh_index + lod.mesh_count).contains(&index) {
-        return Some(PartType::Mesh);
+        return Some(PartType::Normal);
     }
 
     if (lod.water_mesh_index..lod.water_mesh_index + lod.water_mesh_count).contains(&index) {
-        return Some(PartType::WaterMesh);
+        return Some(PartType::Water);
     }
 
     None


### PR DESCRIPTION
I've added a tag to a model part describing whether a mesh is actually a normal mesh or a water mesh. This does *not* need to happen for the other types of mesh because they have [their own mesh list](https://github.com/kaze-xiv/Physis/blob/9544a4711c371bd8cebc6dd0d0dc057373ea7235/src/model/mod.rs#L369). Then I've extended the part converter to check all meshes instead of just looking at mesh meshes.

Now my renderer can find water meshes too :)

<img width="881" height="670" alt="image" src="https://github.com/user-attachments/assets/2ae3e0c9-a2a0-42a6-b3cf-bb9a406434ff" />

Fixes #28.